### PR TITLE
Add `gpg-agent` to the `arm64` package list

### DIFF
--- a/docs/examples/log2ram/user-data
+++ b/docs/examples/log2ram/user-data
@@ -84,7 +84,7 @@ packages:
 ## Create config files
 write_files:
   - path: /etc/systemd/journald.conf
-    permission: "0644"
+    permissions: "0644"
     owner: root:root
     content: |
       [Journal]

--- a/scripts/00-bootstrap.sh
+++ b/scripts/00-bootstrap.sh
@@ -24,7 +24,7 @@ ROOTFS_TAR="${OUTPUT_DIR}/${OS_NAME,,}-${BUILD_ARCH}-${DEBIAN_RELEASE}-${OS_VERS
 ROOTFS_PKGS="${OUTPUT_DIR}/${OS_NAME,,}-${BUILD_ARCH}-${DEBIAN_RELEASE}-${OS_VERSION//.}-packages.txt"
 
 ## Debootstrap config
-DEFAULT_PACKAGES_INCLUDE="apt-transport-https,binutils,ca-certificates,gpg,gpgv,locales,net-tools,wireless-tools,rfkill,wpasupplicant,openssh-server,sudo,usbutils,wget,libpam-systemd,systemd-timesyncd,resolvconf,lsb-release,gettext"
+DEFAULT_PACKAGES_INCLUDE="apt-transport-https,binutils,ca-certificates,gpg,gpgv,gpg-agent,locales,net-tools,wireless-tools,rfkill,wpasupplicant,openssh-server,sudo,usbutils,wget,libpam-systemd,systemd-timesyncd,resolvconf,lsb-release,gettext"
 DEFAULT_PACKAGES_EXCLUDE="debfoster,ntp,info,man-db,paxctld,groff-base,install-info,traceroute,netcat-openbsd"
 
 setup_debootstrap () {


### PR DESCRIPTION
The `gpg-agent` package is required for some `cloud-init` features to work such as check GPG signatures on some APT repositories such as the `docker-ce` one.