### PR TITLE
Use `raspberrypi-sys-mods` firstboot procedure

### DIFF
--- a/rootfs/boot/cmdline.txt
+++ b/rootfs/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes net.ifnames=0 rootwait quiet init=/usr/lib/raspi-config/init_resize.sh
+console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes net.ifnames=0 rootwait quiet init=/usr/lib/raspberrypi-sys-mods/firstboot

--- a/scripts/01-chroot.sh
+++ b/scripts/01-chroot.sh
@@ -91,7 +91,8 @@ apt-get install -y \
     firmware-realtek \
     libraspberrypi0 \
     libraspberrypi-bin \
-    raspi-config
+    raspi-config \
+    raspberrypi-sys-mods
 
 ## Setup OS specifics
 


### PR DESCRIPTION
Since the latest update of BerryOS and within the latest revisions of Raspberry Pi OS Bullseye 2022-09-06 & 2022-09-22 (https://github.com/RPi-Distro/pi-gen/compare/2022-04-04-raspios-bullseye...2022-09-22-raspios-bullseye), RPI-Distro now uses the `firstboot` script provided by the [`raspberrypi-sys-mods` package](https://github.com/RPi-Distro/raspberrypi-sys-mods). This change was implemented in https://github.com/RPi-Distro/pi-gen/commit/7206ab1c222425addfdf206f515a5952ee1ffc78.

This PR updates BerryOS to use this same package for its firstboot routine to take it in line with the upstream version of RaspberryPi OS.

---

### NOTE

This is currently untested, the new `/usr/lib/raspberrypi-sys-mods/firstboot` script provided by `raspberrypi-sys-mods` seems to apply some configuration that weren't done by the original `/usr/lib/raspi-config/init_resize.sh`. Those changes includes:
- Some tweaks to the WiFi hardware configuration (see https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/master/usr/lib/raspberrypi-sys-mods/firstboot#L84-L97)
- The handling of a new configuration file (`/boot/config.toml`) on first boot which requires `python3-toml`, what the presence of this file on firstboot does, its format and how it is handled is still unclear. We must verify what its real goal is and if it may or not conflict with any `cloud-config` configuration before including it as part of BerryOS.

Another point we must verify before adding the [`raspberrypi-sys-mods`](https://github.com/RPi-Distro/raspberrypi-sys-mods) package is the extra system configuration files shipped with it to see they real impact on BerryOS. Potential problematic files includes:
- [`/etc/sudoers.d/010_pi-nopasswd`](https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/master/etc/sudoers.d/010_pi-nopasswd)
- [`/lib/udev.d/rules`](https://github.com/RPi-Distro/raspberrypi-sys-mods/tree/master/lib/udev/rules.d)