### PR TITLE
Update `cloud-init` provider & default configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.2
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update -y -qq \
  && apt-get install -y -qq --no-install-recommends \
             make debootstrap qemu-user-static binfmt-support file \
             parted kpartx dosfstools zerofree xxd \
             rsync wget ca-certificates gpg \
-            bc xz-utils
+            bc xz-utils eatmydata

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In the end, BerryOS is just a stripped down version of [Raspberry Pi OS Lite (St
 
 ### Default environment
 
-If not configured using `/boot/user-data`, BerryOS will be provisioned using its default configuration, this default environment will include the default user accessible via:
+If not configured using `/boot/firmware/user-data`, BerryOS will be provisioned using its default configuration, this default environment will include the default user accessible via:
 
 - Username: `pi`
 - Password: `raspberry`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Download and image sizes have been calculated using `ls -l --block-size=M`.
 
 ### `BerryOS/armhf`
 
-| Stat                   | BerryOS Bookworm (2024.07.04) | RaspiOS Lite Bookworm (2024-03-12) |
+| Stat                   | BerryOS Bookworm (2024.07.05) | RaspiOS Lite Bookworm (2024-03-12) |
 | ---------------------- | ----------------------------- | ---------------------------------- |
 | RAM usage              | 94M                           | 106M                               |
 | Running processes      | 10                            | 16                                 |
@@ -105,7 +105,7 @@ Download and image sizes have been calculated using `ls -l --block-size=M`.
 
 ### `BerryOS/arm64`
 
-| Stat                   | BerryOS Bookworm (2024.07.04) | RaspiOS Lite Bookworm (2024-03-12) |
+| Stat                   | BerryOS Bookworm (2024.07.05) | RaspiOS Lite Bookworm (2024-03-12) |
 | ---------------------- | ----------------------------- | ---------------------------------- |
 | RAM usage              | 118M                          | 126M                               |
 | Running processes      | 10                            | 16                                 |

--- a/docs/config/01-system.md
+++ b/docs/config/01-system.md
@@ -22,7 +22,7 @@ permalink: /docs/config/system/
 
 The main goal of using [`cloud-init`](https://cloud-init.io/) in BerryOS is to be able to easily configure your system during its first startup. It provides quite a lot of possibilities out of the box that we will explore here.
 
-Most of the example shown here are related to your [`/boot/user-data`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/user-data) file unless stated otherwise. This file is the main way you interact with `cloud-init`.
+Most of the example shown here are related to your [`/boot/firmware/user-data`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/firmware/user-data) file unless stated otherwise. This file is the main way you interact with `cloud-init`.
 
 ## Configuring hostname
 

--- a/docs/config/02-users.md
+++ b/docs/config/02-users.md
@@ -20,7 +20,7 @@ permalink: /docs/config/users/
 
 ## Introduction
 
-BerryOS comes by default with a single accessible user created on first boot by [`cloud-init`](https://cloud-init.io/). This default user can be configured or overwritten quite easily in your [`/boot/user-data`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/user-data) file.
+BerryOS comes by default with a single accessible user created on first boot by [`cloud-init`](https://cloud-init.io/). This default user can be configured or overwritten quite easily in your [`/boot/firmware/user-data`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/firmware/user-data) file.
 
 ## Default User
 

--- a/docs/config/03-network.md
+++ b/docs/config/03-network.md
@@ -20,7 +20,7 @@ permalink: /docs/config/network/
 
 ## Introduction
 
-Network configuration in BerryOS is handle by [`cloud-init`](https://cloudinit.readthedocs.io/en/latest/topics/network-config.html) with the help of [`netplan`](https://netplan.io/) inside the [`/boot/network-config`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/network-config) file.
+Network configuration in BerryOS is handle by [`cloud-init`](https://cloudinit.readthedocs.io/en/latest/topics/network-config.html) with the help of [`netplan`](https://netplan.io/) inside the [`/boot/firmware/network-config`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/firmware/network-config) file.
 
 We decided to use the [version 2 networking config format](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html) as it is capable of configuring both the `eth0` and `wlan0` interface on the Raspberry Pi easily thanks to `netplan`'s ability to configure `systemd-networkd` renderer.
 

--- a/docs/config/04-packages.md
+++ b/docs/config/04-packages.md
@@ -21,7 +21,7 @@ lastmod: 2022-06-11T16:59:07.081Z
 
 ## Introduction
 
-During first boot, [`cloud-init`](https://cloud-init.io/) can be asked to manage enabled repositories, installed packages or even upgrade your system using the [Package module](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#package-update-upgrade-install) in your [`/boot/user-data`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/user-data) file.
+During first boot, [`cloud-init`](https://cloud-init.io/) can be asked to manage enabled repositories, installed packages or even upgrade your system using the [Package module](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#package-update-upgrade-install) in your [`/boot/firmware/user-data`](https://github.com/0rax/BerryOS/blob/main/rootfs/boot/firmware/user-data) file.
 
 ## Installing packages
 

--- a/rootfs/.gitattributes
+++ b/rootfs/.gitattributes
@@ -1,2 +1,2 @@
-etc/**		text eol=lf
-boot/**		text eol=crlf
+/etc/**		text eol=lf
+/boot/**	text eol=crlf

--- a/rootfs/etc/cloud/cloud.cfg
+++ b/rootfs/etc/cloud/cloud.cfg
@@ -10,7 +10,8 @@ users:
 # If this is set, 'root' will not be able to ssh in and they
 # will get a message to login instead as the above $user (debian)
 disable_root: true
-apt_preserve_sources_list: true
+apt:
+  preserve_sources_list: true
 
 # This will cause the set+update hostname module to not operate (if true)
 preserve_hostname: false

--- a/rootfs/etc/cloud/cloud.cfg
+++ b/rootfs/etc/cloud/cloud.cfg
@@ -10,11 +10,14 @@ users:
 # If this is set, 'root' will not be able to ssh in and they
 # will get a message to login instead as the above $user (debian)
 disable_root: true
-apt:
-  preserve_sources_list: true
 
 # This will cause the set+update hostname module to not operate (if true)
 preserve_hostname: false
+
+apt:
+  # This prevents cloud-init from rewriting apt's sources.list file,
+  # which has been a source of surprise.
+  preserve_sources_list: true
 
 # If you use datasource_list array, keep array items in a single line.
 # If you use multi line array, ds-identify script won't read array items.
@@ -45,8 +48,9 @@ cloud_init_modules:
 
 # The modules that run in the 'config' stage
 cloud_config_modules:
-  - emit_upstart
+  - snap
   - ssh-import-id
+  - keyboard
   - locale
   - set-passwords
   - grub-dpkg
@@ -62,10 +66,15 @@ cloud_config_modules:
 cloud_final_modules:
   - package-update-upgrade-install
   - fan
+  - landscape
+  - lxd
+  - write-files-deferred
   - puppet
   - chef
-  - salt-minion
   - mcollective
+  - salt-minion
+  - reset_rmc
+  - refresh_rmc_and_interface
   - rightscale_userdata
   - scripts-vendor
   - scripts-per-once
@@ -74,6 +83,7 @@ cloud_final_modules:
   - scripts-user
   - ssh-authkey-fingerprints
   - keys-to-console
+  - install-hotplug
   - phone-home
   - final-message
   - power-state-change
@@ -103,5 +113,4 @@ system_info:
   paths:
     cloud_dir: /var/lib/cloud/
     templates_dir: /etc/cloud/templates/
-    upstart_dir: /etc/init/
   ssh_svcname: ssh

--- a/rootfs/etc/cloud/cloud.cfg.d/99-nocloud.cfg
+++ b/rootfs/etc/cloud/cloud.cfg.d/99-nocloud.cfg
@@ -2,4 +2,4 @@
 datasource_list: [ NoCloud, None ]
 datasource:
   NoCloud:
-    fs_label: boot
+    fs_label: bootfs

--- a/rootfs/usr/lib/berryos/firstboot
+++ b/rootfs/usr/lib/berryos/firstboot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # This file is a tripped down version of https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/b8daae4272db5621ff2c8b2cb8f116711a7bfee4/usr/lib/raspberrypi-sys-mods/firstboot with some minor tweaks to fit the goals of BerryOS.
 #

--- a/rootfs/usr/lib/berryos/firstboot
+++ b/rootfs/usr/lib/berryos/firstboot
@@ -8,7 +8,7 @@
 #
 
 reboot_pi () {
-  umount "$FWLOC"
+  umount "${FWLOC}"
   mount / -o remount,ro
   sync
   reboot -f "$BOOT_PART_NUM"
@@ -18,12 +18,12 @@ reboot_pi () {
 
 get_variables () {
   ROOT_PART_DEV=$(findmnt / -no source)
-  ROOT_DEV_NAME=$(lsblk -no pkname  "$ROOT_PART_DEV")
+  ROOT_DEV_NAME=$(lsblk -no pkname  "${ROOT_PART_DEV}")
   ROOT_DEV="/dev/${ROOT_DEV_NAME}"
 
-  BOOT_PART_DEV=$(findmnt "$FWLOC" -no source)
-  BOOT_PART_NAME=$(lsblk -no kname "$BOOT_PART_DEV")
-  BOOT_DEV_NAME=$(lsblk -no pkname  "$BOOT_PART_DEV")
+  BOOT_PART_DEV=$(findmnt "${FWLOC}" -no source)
+  BOOT_PART_NAME=$(lsblk -no kname "${BOOT_PART_DEV}")
+  BOOT_DEV_NAME=$(lsblk -no pkname  "${BOOT_PART_DEV}")
   BOOT_PART_NUM=$(cat "/sys/block/${BOOT_DEV_NAME}/${BOOT_PART_NAME}/partition")
 
   OLD_DISKID=$(fdisk -l "$ROOT_DEV" | sed -n 's/Disk identifier: 0x\([^ ]*\)/\1/p')
@@ -33,8 +33,8 @@ fix_partuuid() {
   if [ "$BOOT_PART_NUM" != "1" ]; then
     return 0
   fi
-  mount -o remount,rw "$ROOT_PART_DEV"
-  mount -o remount,rw "$BOOT_PART_DEV"
+  mount -o remount,rw "${ROOT_PART_DEV}"
+  mount -o remount,rw "${BOOT_PART_DEV}"
   DISKID="$(dd if=/dev/hwrng bs=4 count=1 status=none | od -An -tx4 | cut -c2-9)"
   fdisk "$ROOT_DEV" > /dev/null <<EOF
 x
@@ -45,12 +45,12 @@ w
 EOF
   if [ "$?" -eq 0 ]; then
     sed -i "s/${OLD_DISKID}/${DISKID}/g" /etc/fstab
-    sed -i "s/${OLD_DISKID}/${DISKID}/" "$FWLOC/cmdline.txt"
+    sed -i "s/${OLD_DISKID}/${DISKID}/" "${FWLOC}/cmdline.txt"
     sync
   fi
 
-  mount -o remount,ro "$ROOT_PART_DEV"
-  mount -o remount,ro "$BOOT_PART_DEV"
+  mount -o remount,ro "${ROOT_PART_DEV}"
+  mount -o remount,ro "${BOOT_PART_DEV}"
 }
 
 main () {
@@ -74,15 +74,15 @@ if ! FWLOC=$(/usr/lib/raspberrypi-sys-mods/get_fw_loc); then
   poweroff -f
 fi
 
-mount "$FWLOC" -o rw
+mount "${FWLOC}" -o rw
 
-sed -i 's| init=/usr/lib/berryos/firstboot||' "$FWLOC/cmdline.txt"
-sed -i 's| sdhci\.debug_quirks2=4||' "$FWLOC/cmdline.txt"
+sed -i 's| init=/usr/lib/berryos/firstboot||' "${FWLOC}/cmdline.txt"
+sed -i 's| sdhci\.debug_quirks2=4||' "${FWLOC}/cmdline.txt"
 
-if ! grep -q splash "$FWLOC/cmdline.txt"; then
-  sed -i "s/ quiet//g" "$FWLOC/cmdline.txt"
+if ! grep -q splash "${FWLOC}/cmdline.txt"; then
+  sed -i "s/ quiet//g" "${FWLOC}/cmdline.txt"
 fi
-mount "$FWLOC" -o remount,ro
+mount "${FWLOC}" -o remount,ro
 sync
 
 main

--- a/scripts/00-bootstrap.sh
+++ b/scripts/00-bootstrap.sh
@@ -25,6 +25,9 @@ OUTPUT_DIR="${BUILD_DIR}/out"
 ROOTFS_TAR="${OUTPUT_DIR}/${OS_NAME,,}-${BUILD_ARCH}-${DEBIAN_RELEASE}-${OS_VERSION//.}-rootfs.tar.xz"
 ROOTFS_PKGS="${OUTPUT_DIR}/${OS_NAME,,}-${BUILD_ARCH}-${DEBIAN_RELEASE}-${OS_VERSION//.}-packages.txt"
 
+## Build cache
+DEBOOTSTRAP_CACHE_DIR="/tmp/debootstrap.cache"
+
 ## Debootstrap config
 DEFAULT_PACKAGES_INCLUDE="apt-transport-https,binutils,busybox,ca-certificates,gpg,gpgv,gpg-agent,locales,net-tools,wireless-tools,rfkill,wpasupplicant,openssh-server,sudo,usbutils,wget,dbus,libpam-systemd,systemd-timesyncd,resolvconf,lsb-release,gettext,zstd"
 DEFAULT_PACKAGES_EXCLUDE="debfoster,ntp,info,man-db,paxctld,groff-base,install-info,traceroute,netcat-openbsd"
@@ -86,10 +89,14 @@ bootstrap_rootfs () {
     chmod 0755 "${ROOTFS_DIR}"
     export ROOTFS_DIR
 
+    # Make sure cache dir exists
+    mkdir -p "${DEBOOTSTRAP_CACHE_DIR}"
+
     # Bootstrap system
     mkdir -p "${ROOTFS_DIR}"
-    debootstrap \
+    eatmydata -- debootstrap \
         "${DEBOOTSTRAP_KEYRING_OPTION}" \
+        --cache-dir="${DEBOOTSTRAP_CACHE_DIR}" \
         --arch="${BUILD_ARCH}" \
         --include="${DEFAULT_PACKAGES_INCLUDE}" \
         --exclude="${DEFAULT_PACKAGES_EXCLUDE}" \

--- a/scripts/01-chroot.sh
+++ b/scripts/01-chroot.sh
@@ -74,6 +74,19 @@ fi
 apt-get update
 apt-get upgrade -y
 
+# Install initramfs-tools
+apt-get install -y \
+    --no-install-recommends \
+    initramfs-tools
+
+# Disable initramfs updates if any package installed after triggers them, initramfs will be regenenerated and updates reneabled later
+if [ -f /etc/initramfs-tools/update-initramfs.conf ]; then
+    sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
+fi
+
+# Disable automatic kernel images symlinking
+echo "do_symlinks=0" > /etc/kernel-img.conf
+
 # Select correct kernel images for request build architecture
 KERNEL_IMAGES=
 case "${BUILD_ARCH}" in
@@ -85,13 +98,9 @@ case "${BUILD_ARCH}" in
     ;;
 esac
 
-# Disable kernel images symlinking
-echo "do_symlinks=0" > /etc/kernel-img.conf
-
-# Install firmwares, bootloader, tools and kernel
+# Install kernels, firmwares, bootloader and tools
 apt-get install -y \
     --no-install-recommends \
-    initramfs-tools \
     ${KERNEL_IMAGES} \
     firmware-atheros \
     firmware-brcm80211 \
@@ -101,11 +110,6 @@ apt-get install -y \
     raspi-firmware \
     raspi-config \
     raspberrypi-sys-mods
-
-# Disable initramfs updates if any package installed after triggers them, initramfs will be regenenerated and update reneabled in the last step here
-if [ -f /etc/initramfs-tools/update-initramfs.conf ]; then
-    sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
-fi
 
 # Remove /etc/sudoers.d/010_pi-nopasswd installed by `raspberrypi-sys-mods`, user account creation and allowing them to assume root is handled by `clout-init`
 rm -f /etc/sudoers.d/010_pi-nopasswd

--- a/scripts/01-chroot.sh
+++ b/scripts/01-chroot.sh
@@ -74,16 +74,6 @@ fi
 apt-get update
 apt-get upgrade -y
 
-# Install initramfs-tools
-apt-get install -y \
-    --no-install-recommends \
-    initramfs-tools
-
-# Disable initramfs updates if any package installed after triggers them, initramfs will be regenenerated and updates reneabled later
-if [ -f /etc/initramfs-tools/update-initramfs.conf ]; then
-    sed -i 's/^update_initramfs=.*/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
-fi
-
 # Disable automatic kernel images symlinking
 echo "do_symlinks=0" > /etc/kernel-img.conf
 
@@ -101,6 +91,7 @@ esac
 # Install kernels, firmwares, bootloader and tools
 apt-get install -y \
     --no-install-recommends \
+    initramfs-tools \
     ${KERNEL_IMAGES} \
     firmware-atheros \
     firmware-brcm80211 \
@@ -189,14 +180,6 @@ systemctl daemon-reload
 # Enable fake-hwclock and store current time
 systemctl enable fake-hwclock
 fake-hwclock save
-
-## Generate initramfs
-
-# Reneable initramfs updates
-sed -i 's/^update_initramfs=.*/update_initramfs=all/' /etc/initramfs-tools/update-initramfs.conf
-
-# Regenerate all initramfs
-update-initramfs -k all -c
 
 ## Cleanup
 apt-get clean


### PR DESCRIPTION
Following the rename of the boot partition in #15, we needed to update the `NoCloud` provider configuration for `cloud-init` to reflect this change. This was forgotten before merging.

This is why release 2024.07.04 has been removed as it broke complete compatibility with `cloud-init`. This issue was sadly not catched during my initial testing yesterday which it should have, I will be looking at adding a simple way to make sure `cloud-init` works before releasing next time.

This PR also change the reference to the old `/boot/user-data` and `/boot/network-config` path to use the new bootfs mount location `/boot/firmware`. As well as some optimization in the bootstraping scripts and a fix to `rootfs/.gitattributes` making `firstboot` unbootable on clone.