### PR TITLE
Force raspbian source.list for armhf arch only

### DIFF
--- a/scripts/01-chroot.sh
+++ b/scripts/01-chroot.sh
@@ -33,9 +33,9 @@ echo "127.0.1.1       ${DEFAULT_HOSTNAME}" >> /etc/hosts
 if [ "${DEBIAN_VARIANT}" == "Raspbian GNU/Linux" ]; then
     DEBIAN_POOLS="main contrib non-free rpi"
     (
-        echo "deb ${DEBOOTSTRAP_URL} ${DEBIAN_RELEASE} ${DEBIAN_POOLS}"
+        echo "deb [arch=armhf] ${DEBOOTSTRAP_URL} ${DEBIAN_RELEASE} ${DEBIAN_POOLS}"
         echo "# Uncomment line below then 'apt-get update' to enable 'apt-get source'"
-        echo "#deb-src ${DEBOOTSTRAP_URL}-security ${DEBIAN_RELEASE}-security ${DEBIAN_POOLS}"
+        echo "#deb-src [arch=armhf] ${DEBOOTSTRAP_URL}-security ${DEBIAN_RELEASE}-security ${DEBIAN_POOLS}"
     ) | tee /etc/apt/sources.list
 else
     DEBIAN_POOLS="main contrib non-free non-free-firmware"


### PR DESCRIPTION
Fixes the following warning on `BerryOS/armhf`:

```
N: Skipping acquire of configured file 'main/binary-arm64/Packages' as repository 'http://raspbian.raspberrypi.org/raspbian bookworm InRelease' doesn't support architecture 'arm64'
N: Skipping acquire of configured file 'contrib/binary-arm64/Packages' as repository 'http://raspbian.raspberrypi.org/raspbian bookworm InRelease' doesn't support architecture 'arm64'
N: Skipping acquire of configured file 'non-free/binary-arm64/Packages' as repository 'http://raspbian.raspberrypi.org/raspbian bookworm InRelease' doesn't support architecture 'arm64'
N: Skipping acquire of configured file 'rpi/binary-arm64/Packages' as repository 'http://raspbian.raspberrypi.org/raspbian bookworm InRelease' doesn't support architecture 'arm64'
```