### PR TITLE
Add config used for testing as examples

### DIFF
--- a/docs/examples/benchmark/user-data
+++ b/docs/examples/benchmark/user-data
@@ -1,0 +1,8 @@
+#cloud-config
+# vim: syntax=yaml
+
+hostname: berryos-benchmark         # Set system hostname
+manage_etc_hosts: true              # Update /etc/hosts with system hostname
+password: berryos                   # Set default user password
+chpasswd: { expire: false }         # Do not expire password after first login
+ssh_pwauth: true                    # Enable SSH password authentication for default user

--- a/docs/examples/docker-ce/arm64/user-data
+++ b/docs/examples/docker-ce/arm64/user-data
@@ -11,7 +11,7 @@ users:
   - default
 
 ## Configure default user access
-password: berryosd
+password: berryos
 chpasswd: { expire: false }
 ssh_pwauth: true
 

--- a/docs/examples/docker-ce/armhf/user-data
+++ b/docs/examples/docker-ce/armhf/user-data
@@ -11,7 +11,7 @@ users:
   - default
 
 ## Configure default user access
-password: berryosd
+password: berryos
 chpasswd: { expire: false }
 ssh_pwauth: true
 

--- a/docs/examples/log2ram/user-data
+++ b/docs/examples/log2ram/user-data
@@ -11,7 +11,7 @@ users:
   - default
 
 ## Configure default user access
-password: berryosd
+password: berryos
 chpasswd: { expire: false }
 ssh_pwauth: true
 

--- a/docs/examples/powerled/config.txt
+++ b/docs/examples/powerled/config.txt
@@ -1,0 +1,88 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[pi4]
+# Run as fast as firmware / board allows
+arm_boost=1
+
+[all]
+
+# GPIO3: Button to power on / off
+# 5V: Power Status Led (always 5V when connected to power)
+# GPIO17: Power Status Led (pull down when poweroff)
+# GPIO27: Activity LED (pull down when poweroff)
+
+dtoverlay=gpio-shutdown,gpio_pin=3,debounce=1000
+gpio=17=op,dh
+dtparam=act_led_trigger=cpu0
+dtoverlay=act-led,activelow=off,gpio=27

--- a/docs/examples/powerled/user-data
+++ b/docs/examples/powerled/user-data
@@ -1,0 +1,6 @@
+#cloud-config
+# vim: syntax=yaml
+
+password: berryos                   # Set default user password
+chpasswd: { expire: false }         # Do not expire password after first login
+ssh_pwauth: true                    # Enable SSH password authentication for default user

--- a/docs/examples/wifi/network-config
+++ b/docs/examples/wifi/network-config
@@ -1,0 +1,16 @@
+version: 2
+ethernets:
+  eth0:
+    addresses:
+      - 10.10.128.200/24
+    dhcp4: false
+    routes:
+      - to: 0.0.0.0/0
+        via: 10.10.128.1
+wifis:
+  wlan0:
+    dhcp4: true
+    optional: true
+    access-points:
+      "My Wi-Fi SSID":
+        password: "My Wi-Fi Password !"

--- a/docs/examples/wifi/user-data
+++ b/docs/examples/wifi/user-data
@@ -1,0 +1,20 @@
+#cloud-config
+# vim: syntax=yaml
+#
+# BerryOS Cloud Config
+#
+
+## Configure language
+locale: en_US.UTF-8
+
+## Configure default user access
+password: berryos                   # Set default user password
+chpasswd: { expire: false }         # Do not expire password after first login
+ssh_pwauth: true                    # Enable SSH password authentication for default user
+
+# # Update package list, upgrade system or install new packages on first boot
+package_update: true                # Update package list
+package_upgrade: true               # Update system package on first-noot
+package_reboot_if_required: true    # Reboot system after installing or upgrading if needed
+packages:                           # Install additional packages
+  - vim


### PR DESCRIPTION
Add new example config files:
- `benchmark`: used to run the RPi 3 B+ benchmarks
- `powerled`: used to add a power button and LED to a Pi (mostly in config.txt), see https://blog.userctl.xyz/posts/2022/06/adding-power-button-status-leds-raspberry-pi/ for a full write-up on how this can be done
- `wifi`: a simple Wi-Fi network configuration