### PR TITLE
Allow network-config update after first-boot

### DIFF
--- a/docs/config/02-users.md
+++ b/docs/config/02-users.md
@@ -106,11 +106,12 @@ users:
     groups:                             # User groups
       [adm, dialout, cdrom, sudo, audio, video, plugdev, games, users, input, render, netdev]
     passwd: berryos                     # User password
-    chpasswd: { expire: false }         # Do not expire user password
-    ssh_pwauth: false                   # Disabble SSH password auth
     ssh_authorized_keys: []             # List of ssh authorized keys
     ssh_import_id:
       - gh:0rax                         # Import authorized keys from GitHub
+
+chpasswd: { expire: false }     # Do not expire user password
+ssh_pwauth: false               # Disabble SSH password auth
 ```
 
 You can also use this directive to create `system` users if the application you will be setting up requires it:

--- a/rootfs/etc/cloud/cloud.cfg
+++ b/rootfs/etc/cloud/cloud.cfg
@@ -8,8 +8,15 @@ users:
   - default
 
 # If this is set, 'root' will not be able to ssh in and they
-# will get a message to login instead as the above $user (debian)
+# will get a message to login instead as the above $user (pi)
 disable_root: true
+
+# Allow password based SSH authentication by default
+ssh_pwauth: true
+
+# Do not expire default password
+chpasswd:
+  expire: false
 
 # This will cause the set+update hostname module to not operate (if true)
 preserve_hostname: false
@@ -88,6 +95,12 @@ cloud_final_modules:
   - final-message
   - power-state-change
 
+# Control when some updates can happen
+updates:
+  # Allow network-config to be re-read and re-generated after firstboot
+  network:
+    when: [boot, hotplug]
+
 # System and/or distro specific settings
 # (not accessible to handlers/transforms)
 system_info:
@@ -102,11 +115,10 @@ system_info:
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
     lock_passwd: false
-    ssh_pwauth: true
-    chpasswd: { expire: false }
-  # Set available network renderers
+  # Set available network renderers and activators (always prefer netplan)
   network:
     renderers: ['netplan', 'eni', 'sysconfig']
+    activators: ['netplan', 'eni', 'networkd']
   # Set default NTP client
   ntp_client: 'systemd-timesyncd'
   # Other config here will be given to the distro class and/or path classes


### PR DESCRIPTION
Allow network-config to be re-read after first boot to allow unattended updates (especially useful when needing to change Wi-Fi password).

Also updated examples and default config to use `chpasswd` and `ssh_pwauth` as top-level values instead of as part of the `default_user` configuration to match the new `user` schema.