### PR TITLE
Update nightly tag to always point to the build commit

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,7 +36,7 @@ jobs:
           DEBIAN_RELEASE: "bookworm"
         run: |
           echo "RELEASE_NAME=BerryOS ${DEBIAN_RELEASE^} ${OS_VERSION^} ($(date --utc "+%Y-%m-%d"))" | tee -a "${GITHUB_ENV}"
-          echo "RELEASE_TAG=${DEBIAN_RELEASE}-${OS_VERSION}" | tee -a "${GITHUB_ENV}"
+          echo "RELEASE_TAG=${DEBIAN_RELEASE}/${OS_VERSION}" | tee -a "${GITHUB_ENV}"
           echo "ARTIFACT_SUFFIX=${DEBIAN_RELEASE,,}-${OS_VERSION//.}" | tee -a "${GITHUB_ENV}"
       - name: Update nightly release
         uses: softprops/action-gh-release@v2
@@ -45,7 +45,7 @@ jobs:
           name: ${{ env.RELEASE_NAME }}
           draft: false
           prerelease: true
-          target_commitish: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
           body: |
             ## Nightly Builds
 
@@ -82,3 +82,13 @@ jobs:
             If you find any issues when using a nightly build, please report them to the [issue tracker](https://github.com/${{ github.repository }}/issues). Make sure to include the content of `/etc/rpi-issue` in your report so we can pin-point the specific build you are using.
           files: out/*
           fail_on_unmatched_files: true
+      - name: Update nightly tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/${{ env.RELEASE_TAG }}',
+              sha: context.sha
+            });

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "RELEASE_PREV=$(gh release view --json tagName -q .tagName)" | tee -a "${GITHUB_ENV}"
           echo "RELEASE_NAME=BerryOS ${DEBIAN_RELEASE^} ${OS_VERSION^}" | tee -a  "${GITHUB_ENV}"
-          echo "RELEASE_TAG=${DEBIAN_RELEASE}-${OS_VERSION}" | tee -a "${GITHUB_ENV}"
+          echo "RELEASE_TAG=${DEBIAN_RELEASE}/${OS_VERSION}" | tee -a "${GITHUB_ENV}"
           echo "ARTIFACT_SUFFIX=${DEBIAN_RELEASE,,}-${OS_VERSION//.}" | tee -a "${GITHUB_ENV}"
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -66,7 +66,7 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ env.RELEASE_NAME }}
           draft: true
-          target_commitish: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
           body: |
             ## Changelog
 


### PR DESCRIPTION
This PR also update the tag format for both release and nightly build where we now use `{debian_release}/{date}` or `{debian_release}/nightly` as our tags to create a better hierarchy in them. This would also allow us to more easily rebuild older versions of Debian on request with fixes from upstream thanks to having per debian release tags now.