### PR TITLE
Add Changelog to Nightly Releases

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -19,6 +19,26 @@ body = """
     {%- endif %}
   {%- raw %}\n{% endraw -%}
 {%- endfor -%}
+{%- if commits | length == 0 -%}
+_No changes since last release._
+{% endif -%}
+"""
+footer = """
+{%- set latest = releases | first | get(key="version") -%}
+{%- set base   = releases | last  | get(key="previous") | get(key="version") -%}
+{%- set commit = releases | first | get(key="commit_id") %}
+{%- raw %}\n{% endraw -%}
+{%- if base and latest -%}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ base }}...{{ latest }}
+{%- elif latest -%}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/commits/{{ latest }}
+{%- elif base and commit -%}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ base }}...{{ commit }}
+{%- elif base -%}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ base }}...HEAD
+{%- else -%}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/commits
+{%- endif -%}
 """
 trim = true
 render_always = true
@@ -37,4 +57,4 @@ commit_parsers = [
 filter_commits = false
 sort_commits = "oldest"
 recurse_submodules = false
-ignore_tags = "bookworm-nightly"
+ignore_tags = "bookworm/nightly"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,8 +36,18 @@ jobs:
           DEBIAN_RELEASE: "bookworm"
         run: |
           echo "RELEASE_NAME=BerryOS ${DEBIAN_RELEASE^} ${OS_VERSION^} ($(date --utc "+%Y-%m-%d"))" | tee -a "${GITHUB_ENV}"
+          echo "RELEASE_PREV=$(gh release view --json tagName -q .tagName)" | tee -a "${GITHUB_ENV}"
           echo "RELEASE_TAG=${DEBIAN_RELEASE}/${OS_VERSION}" | tee -a "${GITHUB_ENV}"
           echo "ARTIFACT_SUFFIX=${DEBIAN_RELEASE,,}-${OS_VERSION//.}" | tee -a "${GITHUB_ENV}"
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: .github/cliff.toml
+          args: --tag "${RELEASE_TAG}" -- "${RELEASE_PREV}..HEAD"
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Update nightly release
         uses: softprops/action-gh-release@v2
         with:
@@ -62,6 +72,10 @@ jobs:
             These builds are provided without any warranty. No manual testing or benchmarks have been performed.
 
             If you prefer a stable release, please download the [latest stable release](https://github.com/${{ github.repository }}/releases/latest).
+
+            ## Changes since last stable release
+
+            ${{ steps.git-cliff.outputs.changelog }}
 
             ## Compatibility
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,8 +47,8 @@ jobs:
           DEBIAN_RELEASE: ${{ inputs.debian_release }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          echo "RELEASE_NAME=BerryOS ${DEBIAN_RELEASE^} ${OS_VERSION^}" | tee -a "${GITHUB_ENV}"
           echo "RELEASE_PREV=$(gh release view --json tagName -q .tagName)" | tee -a "${GITHUB_ENV}"
-          echo "RELEASE_NAME=BerryOS ${DEBIAN_RELEASE^} ${OS_VERSION^}" | tee -a  "${GITHUB_ENV}"
           echo "RELEASE_TAG=${DEBIAN_RELEASE}/${OS_VERSION}" | tee -a "${GITHUB_ENV}"
           echo "ARTIFACT_SUFFIX=${DEBIAN_RELEASE,,}-${OS_VERSION//.}" | tee -a "${GITHUB_ENV}"
       - name: Generate changelog
@@ -70,9 +70,7 @@ jobs:
           body: |
             ## Changelog
 
-            ${{ steps.git-cliff.outputs.content }}
-
-            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.RELEASE_PREV }}...${{ env.RELEASE_TAG }}
+            ${{ steps.git-cliff.outputs.changelog }}
 
             ## Compatibility
 


### PR DESCRIPTION
Also generate changelog links inside `git-cliff` and add an empty state if we ever release without substantial changes or during a nightly following an existing release.